### PR TITLE
circuits, test: Refactor chunkify to make it independent of base 51

### DIFF
--- a/circuits/binmulfast.circom
+++ b/circuits/binmulfast.circom
@@ -12,14 +12,14 @@ template BinMulFast(m, n) {
   var i;
   var j;
 
-  component chunkify1 = Chunkify(m);
-  var numChunks1 = calcChunks(m);
+  component chunkify1 = Chunkify(m, 51);
+  var numChunks1 = calcChunks(m, 51);
   for (i=0; i<m; i++) {
     chunkify1.in[i] <== in1[i];
   }
 
-  component chunkify2 = Chunkify(n);
-  var numChunks2 = calcChunks(n);
+  component chunkify2 = Chunkify(n, 51);
+  var numChunks2 = calcChunks(n, 51);
   for (i=0; i<n; i++) {
     chunkify2.in[i] <== in2[i];
   }

--- a/circuits/chunkify.circom
+++ b/circuits/chunkify.circom
@@ -2,9 +2,9 @@ pragma circom 2.0.0;
 
 include "../node_modules/circomlib/circuits/bitify.circom";
 
-template Chunkify(n) {
+template Chunkify(n, chunkSize) {
   signal input in[n];
-  var numChunks = calcChunks(n);
+  var numChunks = calcChunks(n, chunkSize);
   signal output out[numChunks];
 
   component bitifer[numChunks];
@@ -13,25 +13,25 @@ template Chunkify(n) {
   var offset;
   var numBitsToConvert;
   for (var chunkIndex=0; chunkIndex<numChunks; chunkIndex++) {
-    if (left < 51) {
+    if (left < chunkSize) {
       numBitsToConvert = left;
     } else {
-      numBitsToConvert = 51;
+      numBitsToConvert = chunkSize;
     }
 
     bitifer[chunkIndex] = Bits2Num(numBitsToConvert);
-    offset = 51 * chunkIndex;
+    offset = chunkSize * chunkIndex;
     for (i=0; i<numBitsToConvert; i++) {
       bitifer[chunkIndex].in[i] <== in[offset+i];
     }
     out[chunkIndex] <== bitifer[chunkIndex].out;
-    left -= 51;
+    left -= chunkSize;
   }
 }
 
-function calcChunks(n) {
-  var numChunks = n\51;
-  if (n % 51 != 0) {
+function calcChunks(n, chunkSize) {
+  var numChunks = n\chunkSize;
+  if (n % chunkSize != 0) {
     numChunks++;
   }
   return numChunks;

--- a/test/circuits/chunkify1.circom
+++ b/test/circuits/chunkify1.circom
@@ -2,4 +2,4 @@ pragma circom 2.0.0;
 
 include "../../circuits/chunkify.circom";
 
-component main = Chunkify(256);
+component main = Chunkify(256, 51);


### PR DESCRIPTION
Currently chunkify circuit assumes that it needs to chunks integers for
base 51. But this can be parameterized and we can consider chunkSize as
circuit input.

Signed-off-by: Jinank Jain <jinank94@gmail.com>