### PR TITLE
Output hash of pubkeys and validation bits from batch verification circuit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "sha512"]
 	path = sha512
 	url = git@github.com:Electron-Labs/sha512.git
+[submodule "keccak256-circom"]
+	path = keccak256-circom
+	url = git@github.com:Electron-Labs/keccak256-circom.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,3 @@
-[submodule "circomlib"]
-	path = circomlib
-	url = https://github.com/iden3/circomlib
-[submodule "sha512"]
-	path = sha512
-	url = git@github.com:Electron-Labs/sha512.git
 [submodule "keccak256-circom"]
 	path = keccak256-circom
 	url = git@github.com:Electron-Labs/keccak256-circom.git

--- a/circuits/batchverify.circom
+++ b/circuits/batchverify.circom
@@ -70,5 +70,3 @@ template BatchVerify(n, m) {
   hash[1] <== hashNum2.out;
   verified <== verifiedNum.out;
 }
-
-component main = BatchVerify(80, 1);

--- a/circuits/verify.circom
+++ b/circuits/verify.circom
@@ -10,6 +10,8 @@ include "../node_modules/circomlib/circuits/comparators.circom";
 include "../node_modules/circomlib/circuits/gates.circom";
 
 template Ed25519Verifier(n) {
+  assert(n\8 * 8 == n);
+  
   signal input msg[n];
   
   signal input A[256];

--- a/circuits/verify.circom
+++ b/circuits/verify.circom
@@ -10,7 +10,7 @@ include "../node_modules/circomlib/circuits/comparators.circom";
 include "../node_modules/circomlib/circuits/gates.circom";
 
 template Ed25519Verifier(n) {
-  assert(n\8 * 8 == n);
+  assert(n % 8 == n);
   
   signal input msg[n];
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.26.0",
         "fast-check": "^2.24.0",
+        "keccak256": "1.0.3",
         "mocha": "^9.2.2",
         "mocha-logger": "^1.0.7"
       }
@@ -2594,6 +2595,37 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/keccak": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/keccak/node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true
+    },
+    "node_modules/keccak256": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.3.tgz",
+      "integrity": "sha512-EkF/4twuPm1V/gn75nejOUrKfDUJn87RMLzDWosXF3pXuOvesiSgX35GcmbqzdImCASEkE/WaklWGWSa+Ha5bQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.8",
+        "keccak": "^3.0.1"
       }
     },
     "node_modules/levn": {
@@ -6035,6 +6067,35 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "keccak": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "dev": true,
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+          "dev": true
+        }
+      }
+    },
+    "keccak256": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.3.tgz",
+      "integrity": "sha512-EkF/4twuPm1V/gn75nejOUrKfDUJn87RMLzDWosXF3pXuOvesiSgX35GcmbqzdImCASEkE/WaklWGWSa+Ha5bQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.8",
+        "keccak": "^3.0.1"
       }
     },
     "levn": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-import": "^2.26.0",
     "fast-check": "^2.24.0",
     "mocha": "^9.2.2",
-    "mocha-logger": "^1.0.7"
+    "mocha-logger": "^1.0.7",
+    "keccak256": "1.0.3"
   }
 }


### PR DESCRIPTION
Batch verification will now have three output signals

1. two signals of the hash `hash[2]`, where the the first and second signal represent the first 128 bits and the latter 128 bits from the output of `keccak256`(ethereum compatible)
2. one `verified` signal, wherein the bits (from lsb to msb) will represent whether the signature validation for a particular known publickey passed or not

