### PR TITLE
dependency fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "axios": "^0.27.2",
     "bigint-mod-arith": "^3.1.0",
     "chai": "^4.3.6",
-    "circom_tester": "0.0.14",
+    "circom_tester": "0.0.19",
     "circomlib": "^2.0.5",
     "circomlibjs": "^0.1.7",
     "eslint": "^8.22.0",


### PR DESCRIPTION
tests fail with circom_tester 0.0.14, but run successful with 0.0.19 ( latest ). 
Tested on Ubuntu and MacOS.